### PR TITLE
Fix upload reliability, heartbeat, and server robustness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,361 @@
+# ESP32 Thermal Camera System - Architecture Overview
+
+## Repository Structure
+
+This repository contains a complete thermal imaging and occupancy detection system using an ESP32 microcontroller with an MLX90640 thermal sensor. The system uses a client-server architecture to offload processing from the resource-constrained ESP32 to a more capable laptop/server.
+
+## File Organization
+
+### Core Application Files
+
+#### **ESP32 Scripts (CircuitPython)**
+
+1. **`mlx90640_uploader.py`** (Primary ESP32 Script)
+   - **Purpose**: Lightweight data collection and upload script
+   - **Functionality**:
+     - Reads thermal data from MLX90640 sensor via I2C
+     - Generates compact JSON format (raw temperatures only)
+     - Uploads data to laptop API server via HTTP POST
+     - Configurable upload interval (default: 15 seconds)
+     - Memory-optimized for ESP32 constraints
+   - **Key Features**:
+     - Minimal memory footprint (no web server, no color mapping)
+     - Automatic garbage collection
+     - Error handling for network and sensor issues
+     - WiFi configuration via `settings.toml`
+
+2. **`mlx90640.py`** (Legacy Web Server Script)
+   - **Purpose**: Original implementation with embedded web server
+   - **Functionality**:
+     - Hosts web server directly on ESP32 (port 8080)
+     - Serves thermal images with color mapping
+     - Handles HTTP requests manually using CircuitPython sockets
+     - **Note**: Replaced by client-server architecture for better performance
+
+3. **`test_mlx90640.py`** (Testing/Debugging Script)
+   - **Purpose**: Standalone sensor testing utility
+   - **Functionality**:
+     - Tests I2C communication
+     - Validates sensor initialization
+     - Reads and displays raw temperature data
+     - Helps diagnose hardware/connection issues
+   - **Usage**: Run independently to verify sensor functionality
+
+#### **Server-Side Scripts (Python 3)**
+
+4. **`api_server.py`** (Main API Server)
+   - **Purpose**: Flask-based API server running on laptop
+   - **Functionality**:
+     - Receives thermal data from ESP32 via POST requests
+     - Performs occupancy estimation using computer vision
+     - Serves web interface for real-time visualization
+     - Saves all thermal and occupancy data to disk
+     - Provides REST API endpoints for data access
+   - **Key Components**:
+     - **Data Reception**: `/api/thermal` (POST) - Receives compact thermal data
+     - **Data Retrieval**: `/api/thermal` (GET) - Returns latest thermal data with occupancy
+     - **Occupancy History**: `/api/occupancy/history` - Historical occupancy data
+     - **Occupancy Stats**: `/api/occupancy/stats` - Statistical analysis
+     - **Web Interface**: `/` - Real-time thermal visualization with occupancy graph
+   - **Features**:
+     - Automatic occupancy detection (people counting)
+     - Data persistence (JSON files)
+     - Real-time web dashboard with Chart.js graphs
+     - Temperature-to-color mapping (server-side)
+     - Room temperature estimation
+
+5. **`occupancy_estimator.py`** (Standalone Analysis Tool)
+   - **Purpose**: Independent occupancy analysis script
+   - **Functionality**:
+     - Fetches thermal data from API server
+     - Performs occupancy estimation
+     - Can run single analysis or continuous monitoring
+     - Provides detailed reports
+   - **Use Cases**: 
+     - Offline analysis of saved data
+     - Testing occupancy detection algorithms
+     - Command-line monitoring
+
+### Configuration Files
+
+6. **`settings.toml.example`**
+   - Template for CircuitPython WiFi configuration
+   - Contains placeholders for SSID and password
+   - Must be copied to `settings.toml` on CIRCUITPY drive
+
+7. **`requirements.txt`**
+   - Python dependencies for server-side scripts
+   - Includes: Flask, Flask-CORS, NumPy, SciPy, Requests
+
+### Documentation Files
+
+8. **`README.md`**
+   - Main project documentation
+   - Setup instructions
+   - Usage guidelines
+   - Hardware requirements
+
+9. **`API_SETUP.md`**
+   - Detailed API server setup guide
+   - Network configuration instructions
+   - Troubleshooting tips
+
+## System Architecture
+
+### Data Flow
+
+```
+┌─────────────────┐
+│   MLX90640      │
+│  Thermal Sensor │
+└────────┬────────┘
+         │ I2C
+         ▼
+┌─────────────────┐
+│     ESP32       │
+│  (CircuitPython)│
+│                 │
+│ mlx90640_       │
+│ uploader.py     │
+└────────┬────────┘
+         │ HTTP POST
+         │ (Compact JSON)
+         ▼
+┌─────────────────┐
+│  Laptop/Server  │
+│                 │
+│  api_server.py  │
+│  (Flask)        │
+└────────┬────────┘
+         │
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+┌────────┐ ┌──────────────┐
+│  Web   │ │  Data Files  │
+│ Browser│ │ (thermal_data│
+│        │ │  /)          │
+└────────┘ └──────────────┘
+```
+
+### Component Responsibilities
+
+#### **ESP32 (Edge Device)**
+- **Hardware Interface**: I2C communication with MLX90640
+- **Data Collection**: Reads 24x32 pixel thermal frames (768 temperatures)
+- **Data Format**: Compact JSON with raw temperature values
+- **Network**: WiFi connection, HTTP client
+- **Constraints**: Limited RAM (~520KB), minimal processing
+
+#### **Laptop/Server (Processing Hub)**
+- **Data Reception**: Flask API endpoint for POST requests
+- **Processing**: 
+  - Temperature-to-color mapping
+  - Occupancy estimation (computer vision)
+  - Room temperature calculation
+- **Storage**: File-based persistence (JSON/JSONL)
+- **Visualization**: Web interface with real-time updates
+- **API**: RESTful endpoints for data access
+
+## Key Algorithms
+
+### 1. Occupancy Detection
+
+**Location**: `api_server.py` → `estimate_occupancy()`
+
+**Process**:
+1. Convert thermal data to 2D numpy array (24x32 grid)
+2. Estimate room temperature (median of all pixels)
+3. Create binary mask of human body heat:
+   - Absolute threshold: 30-45°C (human body temperature range)
+   - Relative threshold: Pixels warmer than room by 0.5°C
+   - Combine both conditions (AND operation)
+4. Find connected components (8-connected clustering)
+5. Filter clusters by size (3-200 pixels)
+6. Count valid clusters as people
+
+**Parameters** (configurable):
+- `MIN_HUMAN_TEMP`: 30.0°C
+- `MAX_HUMAN_TEMP`: 45.0°C
+- `MIN_CLUSTER_SIZE`: 3 pixels
+- `MAX_CLUSTER_SIZE`: 200 pixels
+- `ROOM_TEMP_THRESHOLD`: 0.5°C
+
+### 2. Temperature-to-Color Mapping
+
+**Location**: `api_server.py` → `temperature_to_color()`
+
+**Algorithm**:
+- Normalize temperature to 0-1 range (min to max)
+- Color gradient:
+  - 0.0-0.25: Blue to Cyan (cold)
+  - 0.25-0.5: Cyan to Green
+  - 0.5-0.75: Green to Yellow
+  - 0.75-1.0: Yellow to Red (hot)
+
+### 3. Data Formats
+
+**Compact Format** (ESP32 → Server):
+```json
+{
+  "w": 32,
+  "h": 24,
+  "min": 20.5,
+  "max": 35.2,
+  "t": [20.5, 20.6, ...]  // 768 temperature values
+}
+```
+
+**Expanded Format** (Server → Web):
+```json
+{
+  "width": 32,
+  "height": 24,
+  "min_temp": 20.5,
+  "max_temp": 35.2,
+  "pixels": [
+    {"row": 0, "col": 0, "temp": 20.5, "r": 0, "g": 128, "b": 255},
+    ...
+  ]
+}
+```
+
+## Data Storage
+
+### Directory Structure
+```
+thermal_data/
+├── thermal_YYYYMMDD_HHMMSS_MMM_compact.json    # Original ESP32 data
+├── thermal_YYYYMMDD_HHMMSS_MMM_expanded.json  # Processed with colors
+└── occupancy_YYYYMMDD.jsonl                  # Daily occupancy log
+```
+
+### File Formats
+
+1. **Thermal Data Files** (JSON):
+   - Timestamped entries
+   - Both compact and expanded formats saved
+   - Includes full pixel data with colors
+
+2. **Occupancy Log** (JSONL - JSON Lines):
+   - One JSON object per line
+   - Daily files (one per day)
+   - Contains: timestamp, occupancy count, room temperature, cluster data
+
+## Web Interface Features
+
+### Real-Time Dashboard
+- **Thermal Image**: Color-coded 24x32 pixel visualization
+- **Temperature Stats**: Min/Max temperatures displayed
+- **Occupancy Display**: Current person count
+- **Room Temperature**: Estimated background temperature
+- **Occupancy Graph**: Chart.js line chart showing occupancy over time
+- **Auto-Refresh**: Thermal image updates every 1 second, graph every 5 seconds
+
+### API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/thermal` | POST | Receive thermal data from ESP32 |
+| `/api/thermal` | GET | Get latest thermal data with occupancy |
+| `/api/occupancy/history` | GET | Get historical occupancy data (date parameter) |
+| `/api/occupancy/stats` | GET | Get occupancy statistics (date parameter) |
+| `/api/test` | GET | Server health check |
+| `/` | GET | Web interface (HTML page) |
+
+## Memory Optimization Strategies
+
+### ESP32 Constraints
+- **Total RAM**: ~520KB
+- **Challenge**: Web server + sensor + network stack = memory overflow
+- **Solution**: Client-server architecture
+
+### Optimizations Applied
+
+1. **Compact Data Format**: Send only raw temperatures (no colors)
+2. **No Web Server on ESP32**: Offload to laptop
+3. **Aggressive Garbage Collection**: `gc.collect()` after major operations
+4. **Minimal Print Statements**: Reduce string literal memory
+5. **Direct JSON String Building**: Avoid large intermediate dictionaries
+6. **Chunked Socket Sends**: Handle `EAGAIN` errors gracefully
+
+## Configuration
+
+### ESP32 Configuration
+- **WiFi**: Set in `settings.toml` on CIRCUITPY drive
+- **API URL**: Set in `mlx90640_uploader.py` → `API_URL`
+- **Upload Interval**: Set in `mlx90640_uploader.py` → `UPLOAD_INTERVAL`
+
+### Server Configuration
+- **Data Directory**: `api_server.py` → `DATA_DIR`
+- **Data Saving**: `api_server.py` → `SAVE_DATA` (True/False)
+- **Occupancy Parameters**: `api_server.py` → Detection thresholds
+- **Port**: Default 5000 (Flask default)
+
+## Dependencies
+
+### CircuitPython Libraries (ESP32)
+- `adafruit_mlx90640` - Thermal sensor driver
+- `adafruit_bus_device` - I2C bus support
+- Built-in: `wifi`, `socketpool`, `board`, `busio`
+
+### Python Libraries (Server)
+- `flask` - Web framework
+- `flask-cors` - Cross-origin resource sharing
+- `numpy` - Array operations
+- `scipy` - Scientific computing (connected components)
+- `requests` - HTTP client (for occupancy_estimator.py)
+
+## Development History
+
+The project evolved through several iterations:
+
+1. **Initial**: Embedded web server on ESP32 (`mlx90640.py`)
+   - Memory issues with full web server
+   - Port conflicts with CircuitPython web workflow
+
+2. **Optimized**: Memory optimizations applied
+   - Reduced print statements
+   - Optimized JSON generation
+   - Aggressive garbage collection
+
+3. **Current**: Client-server architecture
+   - ESP32 as data collector only
+   - Server handles processing and visualization
+   - Better performance and extensibility
+
+## Usage Workflow
+
+1. **Setup**:
+   - Flash CircuitPython to ESP32
+   - Install libraries via web workflow
+   - Configure WiFi in `settings.toml`
+
+2. **Start Server**:
+   ```bash
+   python3 api_server.py
+   ```
+
+3. **Upload ESP32 Script**:
+   - Copy `mlx90640_uploader.py` to ESP32 as `code.py`
+   - Update `API_URL` with laptop's IP address
+
+4. **View Data**:
+   - Open browser to `http://localhost:5000`
+   - Real-time thermal image and occupancy display
+
+5. **Analyze Data** (Optional):
+   ```bash
+   python3 occupancy_estimator.py --continuous
+   ```
+
+## Future Enhancements
+
+Potential improvements:
+- Database storage (SQLite/PostgreSQL) instead of files
+- Multi-room support with multiple ESP32s
+- Machine learning for better occupancy detection
+- Mobile app interface
+- Historical data analysis dashboard
+- Alert system for occupancy thresholds
+- Integration with home automation systems

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -198,11 +198,12 @@ This repository contains a complete thermal imaging and occupancy detection syst
 **Compact Format** (ESP32 → Server):
 ```json
 {
+  "sensor_id": "room-101",
   "w": 32,
   "h": 24,
   "min": 20.5,
   "max": 35.2,
-  "t": [20.5, 20.6, ...]  // 768 temperature values
+  "t": [20.5, 20.6, ...]
 }
 ```
 
@@ -225,9 +226,9 @@ This repository contains a complete thermal imaging and occupancy detection syst
 ### Directory Structure
 ```
 thermal_data/
-├── thermal_YYYYMMDD_HHMMSS_MMM_compact.json    # Original ESP32 data
-├── thermal_YYYYMMDD_HHMMSS_MMM_expanded.json  # Processed with colors
-└── occupancy_YYYYMMDD.jsonl                  # Daily occupancy log
+├── thermal_{sensor_id}_YYYYMMDD_HHMMSS_MMM_compact.json   # Original ESP32 data
+├── thermal_{sensor_id}_YYYYMMDD_HHMMSS_MMM_expanded.json  # Processed with colors
+└── occupancy_YYYYMMDD.jsonl                               # Daily log, all sensors
 ```
 
 ### File Formats

--- a/api_server.py
+++ b/api_server.py
@@ -32,7 +32,6 @@ ROOM_TEMP_THRESHOLD = 0.5  # Temperature difference from median to consider as b
 latest_thermal_data = None
 last_update_time = None
 latest_occupancy = None  # Store latest occupancy estimate
-_data_counter = 0  # Counter for sequential file naming
 
 # Create data directory if it doesn't exist
 if SAVE_DATA:
@@ -193,8 +192,6 @@ def _sanitize_sensor_id_for_filename(sensor_id):
 
 def save_thermal_data(compact_data, expanded_data, sensor_id=None):
     """Save thermal data to disk."""
-    global _data_counter
-    
     if not SAVE_DATA:
         return
     
@@ -225,7 +222,6 @@ def save_thermal_data(compact_data, expanded_data, sensor_id=None):
                 "data": expanded_data
             }, f, indent=2)
         
-        _data_counter += 1
         print(f"Saved thermal data: {compact_filename.name} ({expanded_filename.name})")
         
     except Exception as e:
@@ -689,4 +685,5 @@ if __name__ == '__main__':
     print("\nWaiting for ESP32 to send thermal data...\n")
     
     # Run on all interfaces so ESP32 can connect. Use PORT from env (e.g. Azure).
-    app.run(host='0.0.0.0', port=port, debug=True)
+    debug = os.environ.get('FLASK_DEBUG', 'false').lower() == 'true'
+    app.run(host='0.0.0.0', port=port, debug=debug)

--- a/api_server.py
+++ b/api_server.py
@@ -685,5 +685,5 @@ if __name__ == '__main__':
     print("\nWaiting for ESP32 to send thermal data...\n")
     
     # Run on all interfaces so ESP32 can connect. Use PORT from env (e.g. Azure).
-    debug = os.environ.get('FLASK_DEBUG', 'false').lower() == 'true'
+    debug = os.environ.get('FLASK_DEBUG', 'false').strip().lower() in {'1', 'true', 'yes', 'on'}
     app.run(host='0.0.0.0', port=port, debug=debug)

--- a/mlx90640_uploader.py
+++ b/mlx90640_uploader.py
@@ -5,6 +5,8 @@ Reads thermal data from MLX90640 sensor and uploads to API server.
 Poll interval: UPLOAD_INTERVAL. When MIN_MEAN_DELTA_C > 0, uploads only if the
 sanitized frame differs from the last successful upload by at least that mean
 absolute °C across pixels. Set MIN_MEAN_DELTA_C to 0 to upload every poll.
+A heartbeat upload is forced at least every HEARTBEAT_INTERVAL_S seconds
+regardless of the delta gate.
 """
 
 import time
@@ -55,6 +57,9 @@ UPLOAD_INTERVAL = 15.0
 # Reduces API traffic when the scene is static. Set to 0 to upload every poll.
 MIN_MEAN_DELTA_C = 0.2
 
+# Force an upload at least this often (seconds), even if the scene hasn't changed.
+HEARTBEAT_INTERVAL_S = 600.0
+
 # Initialize I2C bus
 gc.collect()
 i2c = None
@@ -102,7 +107,7 @@ for attempt in range(5):
         else:
             wifi.radio.connect(ssid=ssid)
         break
-    except ConnectionError as e:
+    except (ConnectionError, OSError, RuntimeError) as e:
         print(f"WiFi attempt {attempt + 1} failed: {e}")
         if attempt < 4:
             time.sleep(2)
@@ -273,9 +278,10 @@ def _upload_thermal_data_once(json_data):
         sock.connect((peer, port))
 
         json_bytes = json_data
+        host_header = API_HOST if port == 80 else f"{API_HOST}:{port}"
         request = (
             f"POST {path} HTTP/1.1\r\n"
-            f"Host: {API_HOST}:{port}\r\n"
+            f"Host: {host_header}\r\n"
             "Content-Type: application/json\r\n"
             f"Content-Length: {len(json_bytes)}\r\n"
             "Connection: close\r\n"
@@ -373,6 +379,7 @@ if mlx is None:
 upload_count = 0
 skip_count = 0
 last_uploaded_frame = None  # sanitized frame from last successful upload; None = upload next
+last_upload_time = None     # monotonic timestamp of last successful upload
 sensor_fail_count = 0
 MAX_SENSOR_FAILS = 5  # Re-initialize sensor after this many consecutive failures
 
@@ -424,7 +431,11 @@ while True:
             time.sleep(UPLOAD_INTERVAL)
             continue
 
-        if MIN_MEAN_DELTA_C > 0 and last_uploaded_frame is not None:
+        heartbeat_due = (
+            last_upload_time is None
+            or (time.monotonic() - last_upload_time) >= HEARTBEAT_INTERVAL_S
+        )
+        if MIN_MEAN_DELTA_C > 0 and last_uploaded_frame is not None and not heartbeat_due:
             delta = mean_abs_frame_diff(sanitized_frame, last_uploaded_frame)
             if delta < MIN_MEAN_DELTA_C:
                 skip_count += 1
@@ -448,6 +459,7 @@ while True:
         if upload_thermal_data(json_data):
             upload_count += 1
             last_uploaded_frame = sanitized_frame
+            last_upload_time = time.monotonic()
             msg = f"Upload #{upload_count}: {min_temp:.1f}°C - {max_temp:.1f}°C"
             if skip_count:
                 msg += f" (skipped {skip_count} unchanged)"

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -4,8 +4,9 @@
 WIFI_SSID = "AirOrangeX"
 # WIFI_PASSWORD = ""
 
-# Unique ID for this sensor (used when uploading to API server). Set a different value per device.
-SENSOR_ID = "sensor-1"
+# Unique ID for this sensor (used when uploading to API server).
+# MUST be changed to a unique value on each device (e.g. "room-101", "lobby").
+SENSOR_ID = "CHANGE_ME"
 
 # Using CIRCUITPY_WIFI_PASSWORD and SSID will autostart the web workflow
 # we can save ~40KB of RAM by not autostarting it simply by using variables

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -5,8 +5,7 @@ WIFI_SSID = "AirOrangeX"
 # WIFI_PASSWORD = ""
 
 # Unique ID for this sensor (used when uploading to API server). Set a different value per device.
-# SENSOR_ID = "living-room"
-# SENSOR_ID = "office"
+SENSOR_ID = "sensor-1"
 
 # Using CIRCUITPY_WIFI_PASSWORD and SSID will autostart the web workflow
 # we can save ~40KB of RAM by not autostarting it simply by using variables


### PR DESCRIPTION
## Summary

- **Heartbeat**: ESP32 now forces an upload every 10 minutes even when the scene is static (bypasses delta gate after `HEARTBEAT_INTERVAL_S = 600 s`)
- **HTTP Host header**: Fixed RFC 7230 violation — default port `:80` is no longer appended, which was causing rejections at some reverse proxies/CDN edges
- **WiFi error handling**: Startup connection now catches `OSError` and `RuntimeError` in addition to `ConnectionError`, matching what CircuitPython actually raises
- **Flask debug mode**: Replaced hardcoded `debug=True` with `FLASK_DEBUG` env-var (defaults off, accepts `1`/`true`/`yes`/`on`) to fix container health checks on Azure Container Apps
- **Cleanup**: Removed unused `_data_counter` variable; updated `settings.toml.example` to use `SENSOR_ID = "CHANGE_ME"` with a per-device warning so devices don't silently collide; corrected upload interval in `ARCHITECTURE.md` (3 s → 15 s); fixed compact format JSON example and filename pattern in docs

## Test plan

- [ ] Flash updated `mlx90640_uploader.py` to ESP32, confirm uploads resume after 10 min of no scene change
- [ ] Verify server accepts POST at `http://` endpoint with corrected Host header (check Azure ingress logs)
- [ ] Simulate WiFi auth failure on startup; confirm retry loop catches the error instead of crashing
- [ ] Start `api_server.py` without `FLASK_DEBUG` set; confirm no reloader subprocess is spawned
- [ ] Start `api_server.py` with `FLASK_DEBUG=1`; confirm debug mode activates
- [ ] Deploy two sensors with distinct `SENSOR_ID` values; confirm `occupancy_YYYYMMDD.jsonl` entries carry the correct `sensor_id` field for each sensor

🤖 Generated with [Claude Code](https://claude.com/claude-code)